### PR TITLE
feat(input): add numpad digit keys (Num0-Num9) to the key editor

### DIFF
--- a/rust/src/keymap.rs
+++ b/rust/src/keymap.rs
@@ -111,6 +111,10 @@ pub const ALL_FLASH_KEYS: &[&str] = &[
     "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
     // Digits 0-9.
     "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+    // Numpad digits 0-9 (distinct Flash key codes from the top-row digits).
+    // Many 2-player Flash games hard-code P2 actions to the numeric keypad.
+    "Num0", "Num1", "Num2", "Num3", "Num4",
+    "Num5", "Num6", "Num7", "Num8", "Num9",
     // Mouse clicks (at the cursor) — for games that need clicking from buttons
     // rather than the touchscreen. Routed to the mouse, not a key event.
     "Clic gauche",
@@ -612,6 +616,12 @@ fn flash_key_name_to_sk(name: &str) -> core::ffi::c_int {
         "3" => crate::SK_3, "4" => crate::SK_4, "5" => crate::SK_5,
         "6" => crate::SK_6, "7" => crate::SK_7, "8" => crate::SK_8,
         "9" => crate::SK_9,
+        // Numpad digits.
+        "Num0" => crate::SK_NUMPAD0, "Num1" => crate::SK_NUMPAD1,
+        "Num2" => crate::SK_NUMPAD2, "Num3" => crate::SK_NUMPAD3,
+        "Num4" => crate::SK_NUMPAD4, "Num5" => crate::SK_NUMPAD5,
+        "Num6" => crate::SK_NUMPAD6, "Num7" => crate::SK_NUMPAD7,
+        "Num8" => crate::SK_NUMPAD8, "Num9" => crate::SK_NUMPAD9,
         // Mouse-click pseudo-keys (routed to the mouse, not the keyboard).
         "Clic gauche" => crate::SK_MOUSE_LEFT,
         "Clic droit" => crate::SK_MOUSE_RIGHT,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1114,6 +1114,21 @@ pub(crate) const SK_ALT: c_int = 48;
 // returns None for them, so they never reach `ruffle_handle_key`.
 pub(crate) const SK_MOUSE_LEFT: c_int = 49;
 pub(crate) const SK_MOUSE_RIGHT: c_int = 50;
+// Numpad digits 0-9 (Flash key codes 96-105, distinct from top-row 48-57).
+// Many local-multiplayer Flash games hard-code Player 2/3/4 actions to the
+// numeric keypad (e.g. Bleach vs Naruto P2 = arrows + Numpad 1-6). Without
+// these, remapping a button to a numpad digit was impossible — the TOUCHES
+// editor only offered the top-row digits, which the game ignores for P2.
+pub(crate) const SK_NUMPAD0: c_int = 51;
+pub(crate) const SK_NUMPAD1: c_int = 52;
+pub(crate) const SK_NUMPAD2: c_int = 53;
+pub(crate) const SK_NUMPAD3: c_int = 54;
+pub(crate) const SK_NUMPAD4: c_int = 55;
+pub(crate) const SK_NUMPAD5: c_int = 56;
+pub(crate) const SK_NUMPAD6: c_int = 57;
+pub(crate) const SK_NUMPAD7: c_int = 58;
+pub(crate) const SK_NUMPAD8: c_int = 59;
+pub(crate) const SK_NUMPAD9: c_int = 60;
 
 fn key_descriptor(code: c_int) -> Option<KeyDescriptor> {
     let (physical, logical) = match code {
@@ -1170,12 +1185,27 @@ fn key_descriptor(code: c_int) -> Option<KeyDescriptor> {
         SK_BACKSPACE => (PhysicalKey::Backspace, LogicalKey::Named(NamedKey::Backspace)),
         SK_CONTROL => (PhysicalKey::ControlLeft, LogicalKey::Named(NamedKey::Control)),
         SK_ALT => (PhysicalKey::AltLeft, LogicalKey::Named(NamedKey::Alt)),
+        SK_NUMPAD0 => (PhysicalKey::Numpad0, LogicalKey::Character('0')),
+        SK_NUMPAD1 => (PhysicalKey::Numpad1, LogicalKey::Character('1')),
+        SK_NUMPAD2 => (PhysicalKey::Numpad2, LogicalKey::Character('2')),
+        SK_NUMPAD3 => (PhysicalKey::Numpad3, LogicalKey::Character('3')),
+        SK_NUMPAD4 => (PhysicalKey::Numpad4, LogicalKey::Character('4')),
+        SK_NUMPAD5 => (PhysicalKey::Numpad5, LogicalKey::Character('5')),
+        SK_NUMPAD6 => (PhysicalKey::Numpad6, LogicalKey::Character('6')),
+        SK_NUMPAD7 => (PhysicalKey::Numpad7, LogicalKey::Character('7')),
+        SK_NUMPAD8 => (PhysicalKey::Numpad8, LogicalKey::Character('8')),
+        SK_NUMPAD9 => (PhysicalKey::Numpad9, LogicalKey::Character('9')),
         _ => return None,
+    };
+    let key_location = if code >= SK_NUMPAD0 && code <= SK_NUMPAD9 {
+        KeyLocation::Numpad
+    } else {
+        KeyLocation::Standard
     };
     Some(KeyDescriptor {
         physical_key: physical,
         logical_key: logical,
-        key_location: KeyLocation::Standard,
+        key_location,
     })
 }
 


### PR DESCRIPTION
## Summary

- Adds 10 new mappable Flash keys **Num0 through Num9** (numpad digits, Flash key codes 96-105) to the TOUCHES control editor and JSON keymap system
- Many local-multiplayer Flash games hard-code Player 2/3/4 actions to the **numeric keypad** (e.g. *Bleach vs Naruto* P2 = arrows + Numpad 1-6, *KOF Wing* P3/P4 numpad). Until now only top-row digits 0-9 (codes 48-57) were available — those games silently ignored them for the numpad-bound players, making P2+ unplayable
- Zero changes to C++ — the input loop already forwards arbitrary `SK_*` integers; only two Rust files touched

## Changes

| File | What |
|---|---|
| `rust/src/lib.rs` | `SK_NUMPAD0`..`SK_NUMPAD9` constants (51-60) + `key_descriptor` match arms with `PhysicalKey::Numpad*` and `KeyLocation::Numpad` |
| `rust/src/keymap.rs` | `Num0`..Num9` added to `ALL_FLASH_KEYS` (dropdown) + `flash_key_name_to_sk` mapping |

## JSON keymap usage

```json
{
  bindings: {
    A: Num1,
    B: Num2
  }
}
```

## Test plan

- [x] Built and tested on hardware (Atmosphère, Switch v18)
- [x] Bleach vs Naruto: P2 buttons mapped to Num1-Num6 now respond correctly (previously silent with top-row 1-6)
- [x] Existing keymaps using top-row digits unaffected
- [x] TOUCHES dropdown shows Num0-Num9 after the existing 0-9 row

🤖 Generated with [Claude Code](https://claude.com/claude-code)