### PR TITLE
Add numpad digit keys (Num0-Num9) to the key editor

### DIFF
--- a/rust/src/keymap.rs
+++ b/rust/src/keymap.rs
@@ -111,6 +111,9 @@ pub const ALL_FLASH_KEYS: &[&str] = &[
     "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
     // Digits 0-9.
     "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+    // Numpad digits 0-9 (distinct Flash key codes from the top-row digits).
+    "Num0", "Num1", "Num2", "Num3", "Num4",
+    "Num5", "Num6", "Num7", "Num8", "Num9",
     // Mouse clicks (at the cursor) — for games that need clicking from buttons
     // rather than the touchscreen. Routed to the mouse, not a key event.
     "Clic gauche",
@@ -612,6 +615,12 @@ fn flash_key_name_to_sk(name: &str) -> core::ffi::c_int {
         "3" => crate::SK_3, "4" => crate::SK_4, "5" => crate::SK_5,
         "6" => crate::SK_6, "7" => crate::SK_7, "8" => crate::SK_8,
         "9" => crate::SK_9,
+        // Numpad digits.
+        "Num0" => crate::SK_NUMPAD0, "Num1" => crate::SK_NUMPAD1,
+        "Num2" => crate::SK_NUMPAD2, "Num3" => crate::SK_NUMPAD3,
+        "Num4" => crate::SK_NUMPAD4, "Num5" => crate::SK_NUMPAD5,
+        "Num6" => crate::SK_NUMPAD6, "Num7" => crate::SK_NUMPAD7,
+        "Num8" => crate::SK_NUMPAD8, "Num9" => crate::SK_NUMPAD9,
         // Mouse-click pseudo-keys (routed to the mouse, not the keyboard).
         "Clic gauche" => crate::SK_MOUSE_LEFT,
         "Clic droit" => crate::SK_MOUSE_RIGHT,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1114,6 +1114,17 @@ pub(crate) const SK_ALT: c_int = 48;
 // returns None for them, so they never reach `ruffle_handle_key`.
 pub(crate) const SK_MOUSE_LEFT: c_int = 49;
 pub(crate) const SK_MOUSE_RIGHT: c_int = 50;
+// Numpad digits 0-9 (Flash key codes 96-105, distinct from top-row 48-57).
+pub(crate) const SK_NUMPAD0: c_int = 51;
+pub(crate) const SK_NUMPAD1: c_int = 52;
+pub(crate) const SK_NUMPAD2: c_int = 53;
+pub(crate) const SK_NUMPAD3: c_int = 54;
+pub(crate) const SK_NUMPAD4: c_int = 55;
+pub(crate) const SK_NUMPAD5: c_int = 56;
+pub(crate) const SK_NUMPAD6: c_int = 57;
+pub(crate) const SK_NUMPAD7: c_int = 58;
+pub(crate) const SK_NUMPAD8: c_int = 59;
+pub(crate) const SK_NUMPAD9: c_int = 60;
 
 fn key_descriptor(code: c_int) -> Option<KeyDescriptor> {
     let (physical, logical) = match code {
@@ -1170,12 +1181,27 @@ fn key_descriptor(code: c_int) -> Option<KeyDescriptor> {
         SK_BACKSPACE => (PhysicalKey::Backspace, LogicalKey::Named(NamedKey::Backspace)),
         SK_CONTROL => (PhysicalKey::ControlLeft, LogicalKey::Named(NamedKey::Control)),
         SK_ALT => (PhysicalKey::AltLeft, LogicalKey::Named(NamedKey::Alt)),
+        SK_NUMPAD0 => (PhysicalKey::Numpad0, LogicalKey::Character('0')),
+        SK_NUMPAD1 => (PhysicalKey::Numpad1, LogicalKey::Character('1')),
+        SK_NUMPAD2 => (PhysicalKey::Numpad2, LogicalKey::Character('2')),
+        SK_NUMPAD3 => (PhysicalKey::Numpad3, LogicalKey::Character('3')),
+        SK_NUMPAD4 => (PhysicalKey::Numpad4, LogicalKey::Character('4')),
+        SK_NUMPAD5 => (PhysicalKey::Numpad5, LogicalKey::Character('5')),
+        SK_NUMPAD6 => (PhysicalKey::Numpad6, LogicalKey::Character('6')),
+        SK_NUMPAD7 => (PhysicalKey::Numpad7, LogicalKey::Character('7')),
+        SK_NUMPAD8 => (PhysicalKey::Numpad8, LogicalKey::Character('8')),
+        SK_NUMPAD9 => (PhysicalKey::Numpad9, LogicalKey::Character('9')),
         _ => return None,
+    };
+    let key_location = if code >= SK_NUMPAD0 && code <= SK_NUMPAD9 {
+        KeyLocation::Numpad
+    } else {
+        KeyLocation::Standard
     };
     Some(KeyDescriptor {
         physical_key: physical,
         logical_key: logical,
-        key_location: KeyLocation::Standard,
+        key_location,
     })
 }
 


### PR DESCRIPTION
Many 2-player Flash games hard-code Player 2 actions to the numeric keypad (e.g. Bleach vs Naruto P2 = Numpad 1-6, KOF Wing P3/P4). The TOUCHES editor currently only offers top-row digits 0-9, which produce different Flash key codes and don't work for these games.

This adds 10 new keys **Num0 through Num9** (Flash key codes 96-105) to the dropdown and JSON keymap system. No C++ changes needed.

**Files changed:**
- `rust/src/lib.rs` — `SK_NUMPAD0..9` constants + `key_descriptor` arms with `KeyLocation::Numpad`
- `rust/src/keymap.rs` — `Num0..Num9` in `ALL_FLASH_KEYS` + `flash_key_name_to_sk`

**JSON usage:** `A: Num1` in a keymap file.

Tested on hardware — Bleach vs Naruto P2 now responds correctly with numpad-mapped buttons.